### PR TITLE
Create additional steps for senior candidates

### DIFF
--- a/project2/README.md
+++ b/project2/README.md
@@ -25,16 +25,34 @@ The overall concept of this project is to deploy a container to EKS that runs a 
 
 1. Python script
 
-    Write a Python script to read the `example.json` file from the S3 bucket, calculate the counts of how many `LOW`, `MEDIUM`, and `HIGH` vulnerabilities are seen PER `vendor_id`, and upload a results file to the same S3 bucket.
+    Write a Python script to read the `example.json` file from the S3 bucket, calculate the counts of how many `LOW`, `MEDIUM`, and `HIGH` vulnerabilities are seen PER `vendor_id`, and upload a results file to the same S3 bucket, or return via http request.
 
 1. Create a Docker image for the Python script
 
 1. Create an ECR registry for the image
 
-1. Create the appropriate Kubernetes manifest(s) to run the Python script and exit
+1. Create the appropriate Kubernetes manifest(s) to run the Python script.
 
 1. Create an IAM role to be associated with the Kubernetes resource to allow the script to access S3
 
+### Senior Candidates Only
+For a senior candidate we'd like to explore more into your Kubernetes knowledge. In the directory flask, there is two python apps and a requirements file, that you can use a template to create your web service. The tasks is to create a simple web service, using a proxy agent that will encompass the above task, and return via HTTP.
+
+1. Create vulnerability image, and deploy service (you can use the vuln.py file as a starting point).
+
+1. Update proxy.py with the appropriate endpoints for vulnerability service
+
+1. Create proxy image, and deploy service fronted by an ALB
+
+1. Deploy nginx service and test you can get access via GET /evil endpoint
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install nginx bitnami/nginx --set service.type=ClusterIP
+```
+
+1. Test that GET /evil works and GET /vulns returns the appropriate data
+
+1. Utilizing a CNI or service mesh and restrict access from the proxy service to the nginx service
 
 ## Things to keep in mind
 

--- a/project2/README.md
+++ b/project2/README.md
@@ -36,21 +36,29 @@ The overall concept of this project is to deploy a container to EKS that runs a 
 1. Create an IAM role to be associated with the Kubernetes resource to allow the script to access S3
 
 ### Senior Candidates Only
-For a senior candidate we'd like to explore more into your Kubernetes knowledge. In the directory flask, there is two python apps and a requirements file, that you can use a template to create your web service. The tasks is to create a simple web service, using a proxy agent that will encompass the above task, and return via HTTP.
+For a senior candidate we'd like to explore more into your Kubernetes knowledge. In the flask directory, there are two python apps and a requirements file, that can be used a template to create your web service. We would like you to create a simple web service (using a proxy) to return the vulnerability data via the proxy service from previously created script.
 
-1. Create vulnerability image, and deploy service (you can use the vuln.py file as a starting point).
+1. Update the Python script previously created to be a Flask application that returns the vulnerability data via HTTP (using `vuln.py` as the starting point)
 
-1. Update proxy.py with the appropriate endpoints for vulnerability service
+1. Update the Docker image to run the Flask application
 
-1. Create proxy image, and deploy service fronted by an ALB
+1. Deploy the Flask application (`vuln.py`) to Kubernetes
 
-1. Deploy nginx service and test you can get access via GET /evil endpoint
+1. Update `proxy.py` with the appropriate endpoints for vulnerability service
+
+1. Create a Docker image for the `proxy.py` service
+
+1. Deploy the proxy service to Kubernetes using an ALB for ingress
+
+1. Deploy a basic NGINX service and test you can get access via GET /evil endpoint
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install nginx bitnami/nginx --set service.type=ClusterIP
 ```
 
-1. Test that GET /evil works and GET /vulns returns the appropriate data
+1. Test that GET /vulns returns the appropriate data
+
+#### Optional
 
 1. Utilizing a CNI or service mesh and restrict access from the proxy service to the nginx service
 

--- a/project2/README.md
+++ b/project2/README.md
@@ -35,7 +35,7 @@ The overall concept of this project is to deploy a container to EKS that runs a 
 
 1. Create an IAM role to be associated with the Kubernetes resource to allow the script to access S3
 
-### Senior Candidates Only
+### Senior Candidates (or anyone looking to have some more fun!)
 For a senior candidate we'd like to explore more into your Kubernetes knowledge. In the flask directory, there are two python apps and a requirements file, that can be used a template to create your web service. We would like you to create a simple web service (using a proxy) to return the vulnerability data via the proxy service from previously created script.
 
 1. Update the Python script previously created to be a Flask application that returns the vulnerability data via HTTP (using `vuln.py` as the starting point)
@@ -50,15 +50,15 @@ For a senior candidate we'd like to explore more into your Kubernetes knowledge.
 
 1. Deploy the proxy service to Kubernetes using an ALB for ingress
 
+1. Test that GET /vulns returns the appropriate data
+
+#### Optional
+
 1. Deploy a basic NGINX service and test you can get access via GET /evil endpoint
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install nginx bitnami/nginx --set service.type=ClusterIP
 ```
-
-1. Test that GET /vulns returns the appropriate data
-
-#### Optional
 
 1. Utilizing a CNI or service mesh and restrict access from the proxy service to the nginx service
 

--- a/project2/flask/proxy.py
+++ b/project2/flask/proxy.py
@@ -1,0 +1,22 @@
+from flask import Flask
+from request import get
+
+app = Flask(__name__)
+
+@app.route('/test')
+def health_check():
+    return "it works"
+
+@app.route('/vulns')
+def vulnerability_proxy():
+    """
+    TODO: Implement get request to backend vulnerability service
+    """
+    pass
+
+@app.route('/evil')
+def evil_proxy():
+    """
+    A function to serve a generic nginx page
+    """
+    get("http://nginx")

--- a/project2/flask/proxy.py
+++ b/project2/flask/proxy.py
@@ -1,0 +1,22 @@
+from flask import Flask
+from requests import get
+
+app = Flask(__name__)
+
+@app.route('/test')
+def health_check():
+    return "it works"
+
+@app.route('/vulns')
+def vulnerability_proxy():
+    """
+    TODO: Implement get request to backend vulnerability service
+    """
+    pass
+
+@app.route('/evil')
+def evil_proxy():
+    """
+    A function to serve a generic nginx page
+    """
+    get("http://nginx")

--- a/project2/flask/requirements.txt
+++ b/project2/flask/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.24.0
+Flask==1.1.2

--- a/project2/flask/vuln.py
+++ b/project2/flask/vuln.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def get_data():
+    """
+    TODO: Implement code that will return vulnerabilities, as described in the README
+    """
+    pass


### PR DESCRIPTION
For our senior candidates, we would like to see them be able to exercise they can deploy multiple Kubernetes microservices of which can communicate with with one another. This PR is designed to provide them with some boiler plate code to give them a starting point when deploying those micro services.

At a high level, this is what a senior candidates would be producing 
![Untitled Diagram](https://user-images.githubusercontent.com/25692880/92247002-90cac600-ee94-11ea-9a1e-7433bd564db7.png)
